### PR TITLE
Fix some issues reported by lintian

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+ukwm (1.2.0-2) UNRELEASED; urgency=medium
+
+  * Use secure URI in Homepage field.
+
+ -- Debian Janitor <janitor@jelmer.uk>  Tue, 05 May 2020 11:47:36 +0000
+
 ukwm (1.2.0-1) unstable; urgency=medium
 
   * New upstream release. (Closes: #952096)

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,8 @@
 ukwm (1.2.0-2) UNRELEASED; urgency=medium
 
   * Use secure URI in Homepage field.
+  * Set upstream metadata fields: Bug-Database, Bug-Submit, Repository,
+    Repository-Browse.
 
  -- Debian Janitor <janitor@jelmer.uk>  Tue, 05 May 2020 11:47:36 +0000
 

--- a/debian/control
+++ b/debian/control
@@ -54,7 +54,7 @@ Build-Depends: debhelper-compat (= 12),
                xauth <!nocheck>
 Standards-Version: 4.5.0
 Rules-Requires-Root: no
-Homepage: http://www.ukui.org
+Homepage: https://www.ukui.org
 Vcs-Git: https://github.com/ukui/ukwm.git
 Vcs-Browser: https://github.com/ukui/ukwm
 

--- a/debian/upstream/metadata
+++ b/debian/upstream/metadata
@@ -1,0 +1,4 @@
+Bug-Database: https://github.com/ukui/ukwm/issues
+Bug-Submit: https://github.com/ukui/ukwm/issues/new
+Repository: https://github.com/ukui/ukwm.git
+Repository-Browse: https://github.com/ukui/ukwm


### PR DESCRIPTION
Fix some issues reported by lintian
* Use secure URI in Homepage field. ([homepage-field-uses-insecure-uri](https://lintian.debian.org/tags/homepage-field-uses-insecure-uri.html))
* Set upstream metadata fields: Bug-Database, Bug-Submit, Repository, Repository-Browse. ([upstream-metadata-file-is-missing](https://lintian.debian.org/tags/upstream-metadata-file-is-missing.html), [upstream-metadata-missing-bug-tracking](https://lintian.debian.org/tags/upstream-metadata-missing-bug-tracking.html), [upstream-metadata-missing-repository](https://lintian.debian.org/tags/upstream-metadata-missing-repository.html))


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/lintian-fixes).

You can follow up to this merge proposal as you normally would.

Build and test logs for this branch can be found at
https://janitor.debian.net/lintian-fixes/pkg/ukwm/a96ff956-8f0d-498c-8928-b2a9d49b54fc.


These changes affect the binary packages; see the
[debdiff](https://janitor.debian.net/api/run/a96ff956-8f0d-498c-8928-b2a9d49b54fc/debdiff?filter_boring=1)


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/a96ff956-8f0d-498c-8928-b2a9d49b54fc/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/a96ff956-8f0d-498c-8928-b2a9d49b54fc/diffoscope)).
