### PR TITLE
Fix some issues reported by lintian

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -2,6 +2,7 @@ ukwm (1.2.1-2) UNRELEASED; urgency=medium
 
   * Bump debhelper from old 12 to 13.
   * Update standards version to 4.6.1, no changes needed.
+  * Avoid explicitly specifying -Wl,--as-needed linker flag.
 
  -- Debian Janitor <janitor@jelmer.uk>  Wed, 02 Nov 2022 01:17:47 -0000
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,7 @@
 ukwm (1.2.1-2) UNRELEASED; urgency=medium
 
   * Bump debhelper from old 12 to 13.
+  * Update standards version to 4.6.1, no changes needed.
 
  -- Debian Janitor <janitor@jelmer.uk>  Wed, 02 Nov 2022 01:17:47 -0000
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+ukwm (1.2.1-2) UNRELEASED; urgency=medium
+
+  * Bump debhelper from old 12 to 13.
+
+ -- Debian Janitor <janitor@jelmer.uk>  Wed, 02 Nov 2022 01:17:47 -0000
+
 ukwm (1.2.1-1) experimental; urgency=medium
 
   [ Debian Janitor ]

--- a/debian/control
+++ b/debian/control
@@ -52,7 +52,7 @@ Build-Depends: debhelper-compat (= 13),
                xkb-data,
                xvfb <!nocheck>,
                xauth <!nocheck>
-Standards-Version: 4.5.0
+Standards-Version: 4.6.1
 Rules-Requires-Root: no
 Homepage: https://www.ukui.org
 Vcs-Git: https://github.com/ukui/ukwm.git

--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Section: x11
 Priority: optional
 Maintainer: Kylin Team <team+kylin@tracker.debian.org>
 Uploaders: handsome_feng <jianfengli@ubuntukylin.com>
-Build-Depends: debhelper-compat (= 12),
+Build-Depends: debhelper-compat (= 13),
                dh-sequence-gir,
                gnome-pkg-tools (>= 0.10),
                gtk-doc-tools (>= 1.15),

--- a/debian/rules
+++ b/debian/rules
@@ -1,6 +1,6 @@
 #!/usr/bin/make -f
 
-export DEB_LDFLAGS_MAINT_APPEND = -Wl,-O1 -Wl,--as-needed
+export DEB_LDFLAGS_MAINT_APPEND = -Wl,-O1
 export DEB_BUILD_MAINT_OPTIONS = hardening=+all
 
 ifneq (,$(findstring $(DEB_HOST_ARCH),"s390x"))


### PR DESCRIPTION
Fix some issues reported by lintian

* Bump debhelper from old 12 to 13. ([package-uses-old-debhelper-compat-version](https://lintian.debian.org/tags/package-uses-old-debhelper-compat-version))

* Update standards version to 4.6.1, no changes needed. ([out-of-date-standards-version](https://lintian.debian.org/tags/out-of-date-standards-version))

* Avoid explicitly specifying -Wl,--as-needed linker flag. ([debian-rules-uses-as-needed-linker-flag](https://lintian.debian.org/tags/debian-rules-uses-as-needed-linker-flag))


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/lintian-fixes). For more information, including instructions on how to disable these merge proposals, see https://janitor.debian.net/lintian-fixes.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts or close the merge proposal when all changes are applied through other means (e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at https://janitor.debian.net/lintian-fixes/pkg/ukwm/928732e5-4878-4f21-ac4e-b9a231dc71cf.



These changes affect the binary packages; see the
[debdiff](https://janitor.debian.net/api/run/928732e5-4878-4f21-ac4e-b9a231dc71cf/debdiff?filter_boring=1)


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/928732e5-4878-4f21-ac4e-b9a231dc71cf/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/928732e5-4878-4f21-ac4e-b9a231dc71cf/diffoscope)).
